### PR TITLE
feat: add kind input for other kind event for trigger node

### DIFF
--- a/nodes/NostrobotsEventTrigger/NostrobotsEventTrigger.node.ts
+++ b/nodes/NostrobotsEventTrigger/NostrobotsEventTrigger.node.ts
@@ -67,6 +67,21 @@ export class NostrobotsEventTrigger implements INodeType {
 				description: 'Public key of target of mention. npub or HEX.',
 			},
 			{
+				displayName: 'Kind',
+				name: 'kind',
+				type: 'number',
+				default: 1,
+				placeholder: '1',
+				noDataExpression: true,
+				required: true,
+				displayOptions: {
+					show: {
+						strategy: ['mention'],
+					},
+				},
+				description: 'Kind number of target Event. Usually set to 1.',
+			},
+			{
 				displayName: 'Relay1',
 				name: 'relay1',
 				type: 'string',
@@ -150,10 +165,14 @@ export class NostrobotsEventTrigger implements INodeType {
 		let closeFunctionWasCalled = false;
 		let pool = new SimplePool();
 
+		// Common params
 		const strategy = this.getNodeParameter('strategy', 0) as string;
 		const relay1 = this.getNodeParameter('relay1', 0) as string;
 		const relay2 = this.getNodeParameter('relay2', 0) as string;
+
+		// Fot mention params
 		const publickey = this.getNodeParameter('publickey', 0) as string;
+		const kindNum = this.getNodeParameter('kind', 0) as number;
 
 		const ratelimitingCountForAll = this.getNodeParameter('ratelimitingCountForAll', 0) as number;
 		const ratelimitingCountForOne = this.getNodeParameter('ratelimitingCountForOne', 0) as number;
@@ -173,6 +192,8 @@ export class NostrobotsEventTrigger implements INodeType {
 			strategy as FilterStrategy,
 			{ mention: publickey },
 			getSecFromMsec(Date.now()),
+			undefined,
+			[kindNum],
 		);
 
 		const eventIdStore = new TimeLimitedKvStore<number>();

--- a/nodes/NostrobotsEventTrigger/NostrobotsEventTrigger.node.ts
+++ b/nodes/NostrobotsEventTrigger/NostrobotsEventTrigger.node.ts
@@ -170,7 +170,7 @@ export class NostrobotsEventTrigger implements INodeType {
 		const relay1 = this.getNodeParameter('relay1', 0) as string;
 		const relay2 = this.getNodeParameter('relay2', 0) as string;
 
-		// Fot mention params
+		// For mention params
 		const publickey = this.getNodeParameter('publickey', 0) as string;
 		const kindNum = this.getNodeParameter('kind', 0) as number;
 

--- a/src/common/filter.spec.ts
+++ b/src/common/filter.spec.ts
@@ -40,6 +40,20 @@ describe('filter.ts', () => {
 			expect(getHex.getHexPubKey).toHaveBeenCalledWith(info.mention);
 		});
 
+		it('should build mention filter with custom kinds', () => {
+			jest.spyOn(getHex, 'getHexPubKey').mockReturnValueOnce('12345678901234567890');
+			const info = { mention: 'npubyyyyyyyyyyyyyyyyyyyy' };
+
+			expect(buildFilter(FilterStrategy.mention, info, 10000, 90000, [1, 7])).toEqual({
+				kinds: [1, 7],
+				'#p': ['12345678901234567890'],
+				since: 10000,
+				until: 90000,
+			});
+
+			expect(getHex.getHexPubKey).toHaveBeenCalledWith(info.mention);
+		});
+
 		it('should build raw filter.', () => {
 			const info = { rawFilter: '{ "kinds": [1],  "#t": ["foodstr"]}' };
 

--- a/src/common/filter.ts
+++ b/src/common/filter.ts
@@ -15,6 +15,7 @@ export function buildFilter(
 	info: Partial<Record<FilterStrategy, string | undefined>>,
 	since?: number,
 	until?: number,
+	kinds = [1],
 ): Filter {
 	let filter = {};
 
@@ -29,7 +30,7 @@ export function buildFilter(
 			const pubkey = getHexPubKey(specificData);
 
 			filter = {
-				kinds: [1],
+				kinds,
 				authors: [pubkey],
 				since,
 				until,
@@ -49,7 +50,7 @@ export function buildFilter(
 			const searchWord = specificData;
 
 			filter = {
-				kinds: [1],
+				kinds,
 				search: searchWord,
 				since,
 				until,
@@ -62,7 +63,7 @@ export function buildFilter(
 			tagString = tagString.replace('#', '');
 
 			filter = {
-				kinds: [1],
+				kinds,
 				'#t': [tagString],
 				since,
 				until,
@@ -89,7 +90,7 @@ export function buildFilter(
 			const mentionedpubkey = getHexPubKey(specificData);
 
 			filter = {
-				kinds: [1],
+				kinds,
 				'#p': [mentionedpubkey],
 				since,
 				until,


### PR DESCRIPTION
Now we can choose other kind in "mention" strategy.

like kind 7 : reaction.

![image](https://github.com/user-attachments/assets/b548753f-e6b0-4dd3-af6a-191d956b2f1b)
